### PR TITLE
Put a trigger in place if card is updated and an Order was placed on Hold in the Last 30 Days should be updated to Pending

### DIFF
--- a/includes/class-wc-payload-gateway.php
+++ b/includes/class-wc-payload-gateway.php
@@ -85,114 +85,122 @@ class WC_Payload_Gateway extends WC_Payment_Gateway {
 
 	// Process the payment
 	public function process_payment( $order_id ) {
-		setup_payload_api();
+		payload_card_update_retry_suppressed( true );
 
-		$order = wc_get_order( $order_id );
+		try {
+			setup_payload_api();
 
-		$get_user_id_from_order = $this->get_order_customer_id($order);	
+			$order = wc_get_order( $order_id );
 
-		// Update subscription payment method if wc subscription exists
-		if (function_exists('wcs_is_subscription') && wcs_is_subscription( $order_id ) ) {
+			$get_user_id_from_order = $this->get_order_customer_id($order);	
 
-			if ( ! $_POST['payment_method_id'] ) {
-				throw new Exception( 'Missing payment method details' );
-			}
+			// Update subscription payment method if wc subscription exists
+			if (function_exists('wcs_is_subscription') && wcs_is_subscription( $order_id ) ) {
+
+				if ( ! $_POST['payment_method_id'] ) {
+					throw new Exception( 'Missing payment method details' );
+				}
+				
+
+				$payment_method = Payload\PaymentMethod::get( $_POST['payment_method_id'] );
+
+				$token = $this->create_token( $payment_method->data() , $get_user_id_from_order  );
+
+				$parent_order = wc_get_order( $order->get_parent_id() );
+
+				$this->update_subscription_order_payment_method( $parent_order, $token, $payment_method );
 			
+				if ( $_POST['update_all_subscriptions_payment_method'] == '1' ) {
+					// Update all subscriptions to the new payment method if selected
+					$subscriptions = wcs_get_users_subscriptions( $get_user_id_from_order );
+					foreach ( $subscriptions as $subscription ) {
+						$subscription_parent_order = wc_get_order( $subscription->get_parent_id() );
+						$this->update_subscription_order_payment_method( $subscription_parent_order, $token, $payment_method );
+					}
+				}
 
-			$payment_method = Payload\PaymentMethod::get( $_POST['payment_method_id'] );
+				return array(
+					'result'   => 'success',
+					'redirect' => $this->get_return_url( $order ),
+				);
+			}
 
-			$token = $this->create_token( $payment_method->data() , $get_user_id_from_order  );
+			// Process payment using token
+			if ( $_POST['token'] || $_POST['payment_method_id'] ) {
+				if ( $_POST['token'] ) {
+					$token = WC_Payment_Tokens::get( $_POST['token'] );
+				} else {
+					$payment_method = Payload\PaymentMethod::get( $_POST['payment_method_id'] );
+					$token          = $this->create_token( $payment_method->data()  , $get_user_id_from_order);
 
-			$parent_order = wc_get_order( $order->get_parent_id() );
+					// Create and set token if subscription
+					if ( wcs_order_contains_subscription( $order_id ) ) {
+						$this->update_subscription_order_payment_method( $order, $token, $payment_method );
+					}
+				}
 
-			$this->update_subscription_order_payment_method( $parent_order, $token, $payment_method );
-		
-			if ( $_POST['update_all_subscriptions_payment_method'] == '1' ) {
-				// Update all subscriptions to the new payment method if selected
-				$subscriptions = wcs_get_users_subscriptions( $get_user_id_from_order );
-				foreach ( $subscriptions as $subscription ) {
-					$subscription_parent_order = wc_get_order( $subscription->get_parent_id() );
-					$this->update_subscription_order_payment_method( $subscription_parent_order, $token, $payment_method );
+				$this->maybe_retry_on_hold_order( $order, $token );
+
+				try {
+					$payment = $this->create_payment_for_order( $order, $order->get_total(), $token->get_token() );
+				} catch ( TransactionDeclined $e ) {
+					wc_add_notice( __( 'Payment error:', 'woothemes' ) . $e->error_description, 'error' );
+					return array(
+						'result' => 'failure',
+					);
 				}
 			}
 
+			// Confirm payment processed on client side
+			else {
+
+				if ( ! $_POST['transactionid'] ) {
+					throw new Exception( 'Missing payment details' );
+				}
+
+				$payment = Payload\Transaction::get( $_POST['transactionid'] );
+
+				$amt = $order->get_total();
+
+				if ( $amt != $payment->amount ) {
+					throw new Exception( 'Mismatched Amount' );
+				}
+
+				
+				
+
+				if ( ! $payment->customer_id ) {
+					$payload_customer_id = get_payload_customer_id();
+					if ( $payload_customer_id ) {
+						
+						$payment->update( array( 'customer_id' => $payload_customer_id ) );
+					
+						$payment_method = Payload\PaymentMethod::get( $payment->payment_method_id );
+						$payment_method->update( array( 'account_id' => $payload_customer_id ) );
+					}
+				}
+
+				$order->set_transaction_id( $payment->ref_number );
+
+				// Create and set token if subscription
+				if ( function_exists("WC_Subscriptions_Order") && WC_Subscriptions_Order::order_contains_subscription( $order_id ) ) {
+					$token = $this->create_token( $payment->payment_method , $this->set_customer_id_by_order($order)  );
+					$order->add_payment_token( $token );
+				}
+			}
+
+		
+				$payment = $this->handle_order_payment( $order, $payment );
+
+
+			// Redirect to the thank you page
 			return array(
 				'result'   => 'success',
 				'redirect' => $this->get_return_url( $order ),
 			);
+		} finally {
+			payload_card_update_retry_suppressed( false );
 		}
-
-		// Process payment using token
-		if ( $_POST['token'] || $_POST['payment_method_id'] ) {
-			if ( $_POST['token'] ) {
-				$token = WC_Payment_Tokens::get( $_POST['token'] );
-			} else {
-				$payment_method = Payload\PaymentMethod::get( $_POST['payment_method_id'] );
-				$token          = $this->create_token( $payment_method->data()  , $get_user_id_from_order);
-
-				// Create and set token if subscription
-				if ( wcs_order_contains_subscription( $order_id ) ) {
-					$this->update_subscription_order_payment_method( $order, $token, $payment_method );
-				}
-			}
-
-			try {
-				$payment = $this->create_payment_for_order( $order, $order->get_total(), $token->get_token() );
-			} catch ( TransactionDeclined $e ) {
-				wc_add_notice( __( 'Payment error:', 'woothemes' ) . $e->error_description, 'error' );
-				return array(
-					'result' => 'failure',
-				);
-			}
-		}
-
-		// Confirm payment processed on client side
-		else {
-
-			if ( ! $_POST['transactionid'] ) {
-				throw new Exception( 'Missing payment details' );
-			}
-
-			$payment = Payload\Transaction::get( $_POST['transactionid'] );
-
-			$amt = $order->get_total();
-
-			if ( $amt != $payment->amount ) {
-				throw new Exception( 'Mismatched Amount' );
-			}
-
-			
-			
-
-			if ( ! $payment->customer_id ) {
-				$payload_customer_id = get_payload_customer_id();
-				if ( $payload_customer_id ) {
-					
-					$payment->update( array( 'customer_id' => $payload_customer_id ) );
-				
-					$payment_method = Payload\PaymentMethod::get( $payment->payment_method_id );
-					$payment_method->update( array( 'account_id' => $payload_customer_id ) );
-				}
-			}
-
-			$order->set_transaction_id( $payment->ref_number );
-
-			// Create and set token if subscription
-			if ( function_exists("WC_Subscriptions_Order") && WC_Subscriptions_Order::order_contains_subscription( $order_id ) ) {
-				$token = $this->create_token( $payment->payment_method , $this->set_customer_id_by_order($order)  );
-				$order->add_payment_token( $token );
-			}
-		}
-
-	
-			$payment = $this->handle_order_payment( $order, $payment );
-
-
-		// Redirect to the thank you page
-		return array(
-			'result'   => 'success',
-			'redirect' => $this->get_return_url( $order ),
-		);
 	}
 
 	public function add_payment_method() {
@@ -216,6 +224,7 @@ class WC_Payload_Gateway extends WC_Payment_Gateway {
 		$order->set_payment_method( $token->get_id() );
 		$order->set_payment_method_title( $payment_method->description );
 		$order->save();
+		$this->maybe_retry_on_hold_order( $order, $token );
 	}
 
 	public function scheduled_subscription_payment( $amount, $renewal_order, $retry = true, $previous_error = false ) {
@@ -235,20 +244,55 @@ class WC_Payload_Gateway extends WC_Payment_Gateway {
 
 			$token = WC_Payment_Tokens::get( $token_id );
 
-			if ( is_null( $token ) ) {
-				// Legacy support from version <=1.0.0
-				$tokens = $parent_order->get_payment_tokens();
+            if ( is_null( $token ) ) {
+                // Legacy support from version <=1.0.0
+                $log = wc_get_logger();
+                $tokens = $parent_order->get_payment_tokens();
 
-				if ( count( $tokens ) == 0 ) {
-					throw new Exception( 'No available payment method' );
-				}
+                if ( count( $tokens ) == 0 ) {
+                    $log->error( 'No available payment method for order ' . $parent_order->get_id(), array( 'source' => 'payload' ) );
+                    
+                    $note = __( 'Automatic subscription payment failed: No payment method on file for this account.', 'payload' );
+                    $renewal_order->add_order_note( $note );
+                    $renewal_order->save();
+                    set_transient('my_admin_flash_notice_' . get_current_user_id(), [
+  'message' => 'Automatic subscription payment failed: No payment method on file for this account.',
+  'type' => 'error',
+], 60);
 
-				$token = WC_Payment_Tokens::get( $tokens[0] );
+                    $admin_email = get_option( 'admin_email' );
+                    if ( $admin_email ) {
+                        wp_mail(
+                            $admin_email,
+                            sprintf( __( 'Subscription Payment Failed - Order #%s', 'payload' ), $renewal_order->get_id() ),
+                            sprintf( __( "Automatic subscription payment could not be processed for order #%s.\n\nReason: No payment method on file.\n\nPlease contact the customer to update their payment information.", 'payload' ), $renewal_order->get_id() )
+                        );
+                    }
+                    
+                    return;
+                }
 
-				if ( is_null( $token ) ) {
-					throw new Exception( 'No available payment method' );
-				}
-			}
+                $token = WC_Payment_Tokens::get( $tokens[0] );
+
+                if ( is_null( $token ) ) {
+                    $log->error( 'Invalid payment token for order ' . $parent_order->get_id(), array( 'source' => 'payload' ) );
+                    
+                    $note = __( 'Automatic subscription payment failed: Invalid payment method on file.', 'payload' );
+                    $renewal_order->add_order_note( $note );
+                    $renewal_order->save();
+                    
+                    $admin_email = get_option( 'admin_email' );
+                    if ( $admin_email ) {
+                        wp_mail(
+                            $admin_email,
+                            sprintf( __( 'Subscription Payment Failed - Order #%s', 'payload' ), $renewal_order->get_id() ),
+                            sprintf( __( "Automatic subscription payment could not be processed for order #%s.\n\nReason: Invalid payment method on file.", 'payload' ), $renewal_order->get_id() )
+                        );
+                    }
+                    
+                    return;
+                }
+            }
 
 			$payment_method_id = $token->get_token();
 			break;
@@ -327,6 +371,79 @@ class WC_Payload_Gateway extends WC_Payment_Gateway {
 		return $token;
 	}
 
+	protected function maybe_retry_on_hold_order( $order, $token ) {
+		if ( ! $order instanceof WC_Order ) {
+			return;
+		}
+
+		if ( ! $token instanceof WC_Payment_Token ) {
+			return;
+		}
+
+		if ( 'on-hold' !== $order->get_status() ) {
+			return;
+		}
+
+		$current_token_id = $order->get_payment_method();
+
+		if ( strval( $current_token_id ) === strval( $token->get_id() ) ) {
+			return;
+		}
+
+		$order->set_payment_method( $token->get_id() );
+
+		if ( method_exists( $token, 'get_card_type' ) && method_exists( $token, 'get_last4' ) && $token->get_last4() ) {
+			$method_title = sprintf(
+				__( '%1$s ending in %2$s', 'payload' ),
+				strtoupper( $token->get_card_type() ),
+				$token->get_last4()
+			);
+			$order->set_payment_method_title( $method_title );
+		}
+
+		$order->set_status( 'pending' );
+
+		$note = sprintf(
+			__( 'Payment method updated to card ending in %s after a previous card issue. Order moved to pending for retry.', 'payload' ),
+			$token->get_last4()
+		);
+
+		$order->add_order_note( $note );
+		$order->save();
+
+		$this->notify_payment_retry_parties( $order, $token, $note );
+	}
+
+	protected function notify_payment_retry_parties( $order, $token, $note ) {
+		if ( ! $order instanceof WC_Order || ! $token instanceof WC_Payment_Token ) {
+			return;
+		}
+
+		$order_number = method_exists( $order, 'get_order_number' ) ? $order->get_order_number() : $order->get_id();
+
+		$subject = sprintf(
+			__( 'Order #%s payment retry notice', 'payload' ),
+			$order_number
+		);
+
+		$message_body = sprintf(
+			__( "Order #%1\$s experienced a payment issue. The payment method has been updated to card ending in %2\$s and the order is now pending for a new attempt.\n\nNote: %3\$s", 'payload' ),
+			$order_number,
+			$token->get_last4(),
+			$note
+		);
+
+		$admin_email = get_option( 'admin_email' );
+		if ( $admin_email ) {
+			wp_mail( $admin_email, $subject, $message_body );
+		}
+
+		$customer_email = $order->get_billing_email();
+		if ( $customer_email && is_email( $customer_email ) ) {
+			wp_mail( $customer_email, $subject, $message_body );
+		}
+	}
+
 	public function is_virtual($order_id){
 		
 		$order = wc_get_order( $order_id );
@@ -374,7 +491,9 @@ class WC_Payload_Gateway extends WC_Payment_Gateway {
 								$parent_payment_method = Payload\PaymentMethod::get( $parent_pm_id );
 								if ( ! empty( $parent_payment_method->account_id ) ) {
 									$payload_customer_id = $parent_payment_method->account_id;
-								}
+								}else{
+                                    $payload_customer_id = get_payload_customer_id();
+                                }
 							} catch ( Exception $e ) {
 								// ignore if Payload lookup fails
 							}

--- a/payload-woocommerce.php
+++ b/payload-woocommerce.php
@@ -150,6 +150,45 @@ add_action( 'woocommerce_payment_complete', function( $order_id ) {
 
 });
 
+/**
+ * Plugin Name: Admin Flash Notice Example
+ */
+
+add_action('admin_init', function () {
+	// Example trigger: append ?my_notice=1 to any wp-admin URL
+	if (!current_user_can('manage_options')) return;
+
+	if (isset($_GET['my_notice']) && $_GET['my_notice'] === '1') {
+		set_transient('my_admin_flash_notice_' . get_current_user_id(), [
+			'message' => '✅ Settings saved successfully.',
+			'type'    => 'success', // success | warning | error | info
+		], 60); // seconds
+	}
+});
+
+add_action('admin_notices', function () {
+	if (!current_user_can('manage_options')) return;
+
+	$key  = 'my_admin_flash_notice_' . get_current_user_id();
+	$data = get_transient($key);
+
+	if (!$data) return;
+
+	delete_transient($key);
+
+	$type    = isset($data['type']) ? $data['type'] : 'info';
+	$message = isset($data['message']) ? $data['message'] : '';
+
+	$allowed = ['success', 'warning', 'error', 'info'];
+	if (!in_array($type, $allowed, true)) $type = 'info';
+
+	printf(
+		'<div class="notice notice-%1$s is-dismissible"><p>%2$s</p></div>',
+		esc_attr($type),
+		esc_html($message)
+	);
+});
+
 function get_payload_customer_id() {
 	$payload_customer_id = null;
 
@@ -260,4 +299,114 @@ function payload_subscription_payment_method_to_display( $label, $subscription, 
 	return $parent_order->get_payment_method_title();
 	}
 	return "No Payment Method available at this time.";
+}
+
+add_action( 'woocommerce_new_payment_token', 'payload_retry_orders_after_card_update', 10, 2 );
+add_action( 'woocommerce_payment_token_set_default', 'payload_retry_orders_after_card_update', 10, 2 );
+
+function payload_retry_orders_after_card_update( $token_id, $token = null ) {
+	if ( payload_card_update_retry_suppressed() ) {
+		return;
+	}
+
+	if ( ! $token instanceof WC_Payment_Token ) {
+		$token = WC_Payment_Tokens::get( $token_id );
+	}
+
+	if ( ! $token instanceof WC_Payment_Token ) {
+		return;
+	}
+
+	if ( 'payload' !== $token->get_gateway_id() ) {
+		return;
+	}
+
+	$user_id = $token->get_user_id();
+	if ( ! $user_id ) {
+		return;
+	}
+
+	setup_payload_api();
+
+	$args   = array(
+		'customer_id'    => $user_id,
+		'status'         => array( 'wc-on-hold', 'wc-pending' ),
+		'payment_method' => 'payload',
+		'type'           => array( 'shop_order', 'shop_subscription' ),
+		'limit'          => -1,
+		'orderby'        => 'date',
+		'order'          => 'ASC',
+	);
+	$orders = wc_get_orders( $args );
+
+	if ( empty( $orders ) ) {
+		return;
+	}
+
+	$gateway = payload_get_gateway_instance();
+
+	if ( ! $gateway ) {
+		return;
+	}
+
+	foreach ( $orders as $order ) {
+		if ( ! $order instanceof WC_Order ) {
+			continue;
+		}
+
+		if ( strval( $order->get_payment_method() ) !== strval( $token->get_id() ) ) {
+			$order->set_payment_method( $token->get_id() );
+
+			if ( method_exists( $token, 'get_card_type' ) && method_exists( $token, 'get_last4' ) && $token->get_last4() ) {
+				$method_title = sprintf(
+					__( '%1$s ending in %2$s', 'payload' ),
+					strtoupper( $token->get_card_type() ),
+					$token->get_last4()
+				);
+				$order->set_payment_method_title( $method_title );
+			}
+
+			$order->save();
+		}
+
+		try {
+			$gateway->create_payment_for_order( $order, $order->get_total(), $token->get_token() );
+			$order->add_order_note( __( 'Automatically retried payment after customer updated saved card.', 'payload' ) );
+		} catch ( Exception $e ) {
+			$order->add_order_note(
+				sprintf(
+					__( 'Automatic retry after card update failed: %s', 'payload' ),
+					$e->getMessage()
+				)
+			);
+		}
+	}
+}
+
+function payload_get_gateway_instance() {
+	if ( function_exists( 'WC' ) ) {
+		$payment_gateways = WC()->payment_gateways();
+		if ( $payment_gateways ) {
+			$gateways = $payment_gateways->payment_gateways();
+			if ( isset( $gateways['payload'] ) && $gateways['payload'] instanceof WC_Payload_Gateway ) {
+				return $gateways['payload'];
+			}
+		}
+	}
+
+	if ( class_exists( 'WC_Payload_Gateway' ) ) {
+		return new WC_Payload_Gateway();
+	}
+
+	return null;
+}
+
+function payload_card_update_retry_suppressed( $status = null ) {
+	static $suppressed = false;
+
+	if ( null !== $status ) {
+		$suppressed = (bool) $status;
+	}
+
+	return $suppressed;
 }


### PR DESCRIPTION
-  System provide better error response instead of breaking the backoffice when subscription user dont have payment method on file
- System attempt to retry On-hold payment if customer update their card
- Admin notices add for better on screen error reporting
- Admin and Customer get email notification when payment failed they get notify as to what action should be taken next
